### PR TITLE
Updates the bandcamp web interface

### DIFF
--- a/mopidy_bandcamp/web.py
+++ b/mopidy_bandcamp/web.py
@@ -23,18 +23,57 @@ class WebHandler(tornado.web.RequestHandler):
         else:
             self.write(
                 """<!DOCTYPE html>
-<html><head><title>Add a bandcamp URL</title></head>
-<body><div><h1>Add a bandcamp URL to Mopidy tracklist</h1>
-<form><p>URL: <input name="url" type="text" /></p><p><input type="submit" /></p></form><p></div>
-<div><h1>Why is this here?</h1>
-<p>The purpose of this is to be able to easily add bandcamp albums to Mopidy from your web browser.</p>
-<textarea id="bookmark" rows="4" cols="80"></textarea>
-<script>document.getElementById('bookmark').value="javascript:s='" + window.location +
-"';f=document.createElement('form');f.action=s;i=document.createElement('input');i.type='hidden';" +
-"i.name='url';i.value=window.location.href;f.appendChild(i);document.body.appendChild(f);f.submit();"
-</script>
-<p>Copy the above snippet, and create a bookmark in your web browser with the snippet as the URL.<br/>
-When you're browsing bandcamp, you can simply click that bookmark to add the current page to Mopidy.</p>
-<a href="https://github.com/impliedchaos/mopidy-bandcamp#web-client">more info</a></div></body></html>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>Mopidy-Bandcamp</title>
+
+  <script type="text/javascript">
+    var file = "http://" + window.location.host + "/mopidy/mopidy.css";  /* use mopidy's css */
+    var link = document.createElement("link");
+    link.href = file;
+    link.type = "text/css";
+    link.rel = "stylesheet";
+    link.media = "screen,print";
+    document.getElementsByTagName("head")[0].appendChild(link);
+  </script>
+</head>
+<body><div class="box focus">
+    <h1>Mopidy-Bandcamp</h1>
+    <p>
+      The purpose of this webclient is to be able to easily add bandcamp 
+      albums to Mopidy from your web browser.
+    </p>
+  </div>
+
+  <div class="box">
+    <p>
+    <div>
+      <h2>Add a bandcamp URL to Mopidy tracklist</h2>
+      <form>
+        <table style="width: 100%;"><tr>
+          <td style="width: 10%;">URL: </td>
+          <td style="width: 80%;"><input style="width: 98%;" name="url" type="text" /></td>
+          <td style="width: 10%;"><input style="width: 100%;" type="submit" /></td>
+        </tr></table>
+      </form>
+      <p>
+    </div>
+    <div>
+      <h2>Add a bandcamp URL to Mopidy tracklist while browsing</h2>
+      <textarea id="bookmark" rows="4" style="width: 100%;"></textarea>
+        <script>document.getElementById('bookmark').value="javascript:s='" + window.location +
+            "';f=document.createElement('form');f.action=s;i=document.createElement('input');i.type='hidden';" +
+            "i.name='url';i.value=window.location.href;f.appendChild(i);document.body.appendChild(f);f.submit();"
+        </script>
+      <p>
+        <h3>Why is this here?</h3>
+        <p>Copy the above snippet, and create a bookmark in your web browser with the snippet as the URL. 
+           When you're browsing bandcamp, you can simply click that bookmark to add the current page to Mopidy.</p>
+           <a href="https://github.com/impliedchaos/mopidy-bandcamp#web-client">more info</a>
+      </p>
+    </div>
+  </div>
+</div></body></html>
 """
             )


### PR DESCRIPTION
I really liked `mopidy-bandcamp's` web interface that allows adding of tracks, and your browser shortcut with the same purpose, so I copied them into my own mopidy backend, [`mopidy-youtube`](https://github.com/natumbri/mopidy-youtube).  

When I was building the web frontend, I tried to make the formatting reflect the  default mopidy web frontend formatting, primarily by using the `mopidy.css` style sheet.  

This pull request basically applies the `mopidy.css` stylesheet to the `bandcamp` web frontend.  Not a huge deal, and feel free to accept or not, obviously; the OCD in me just likes the web frontends to all look the same!

Cheers,
Nik