### PR TITLE
Put the More (discover/collection) item at the end

### DIFF
--- a/mopidy_bandcamp/library.py
+++ b/mopidy_bandcamp/library.py
@@ -92,7 +92,7 @@ class BandcampLibraryProvider(backend.LibraryProvider):
                         out.append(
                             Ref.directory(
                                 uri="bandcamp:" + colltype + ":" + data["last_token"],
-                                name="More...",
+                                name="\ufeffMore...",
                             )
                         )
                 except Exception:
@@ -144,7 +144,7 @@ class BandcampLibraryProvider(backend.LibraryProvider):
                 pagenum += self.pages
                 out.append(
                     Ref.directory(
-                        uri=f"bandcamp:{stype}:{sid}:{pagenum}", name="More..."
+                        uri=f"bandcamp:{stype}:{sid}:{pagenum}", name="\ufeffMore..."
                     )
                 )
             return out


### PR DESCRIPTION
It seems the Mopidy-Iris frontend sorts by the name of the entry so this adds a whitespace character to make the More entry sort at the end of the list.